### PR TITLE
fix incorrect parameters passed to keyboard and mouse constructor

### DIFF
--- a/lib/webrtcstreamer.js
+++ b/lib/webrtcstreamer.js
@@ -226,7 +226,7 @@ export default class WebRtcStreamer {
     // Mouse button state
     let buttonMask = 0;
 
-    this.keyboard = new Keyboard(document);
+    this.keyboard = new Keyboard({ target: document });
     this.keyboard.onkeyevent = (keysym, code, down) => {
       this.onKeyboardEvent({
         down,
@@ -234,7 +234,7 @@ export default class WebRtcStreamer {
       });
     };
 
-    this.mouse = new Mouse(elem);
+    this.mouse = new Mouse({ target: elem });
     this.mouse.onmousebutton = (x, y, down, bmask) => {
       if (down) {
         buttonMask |= bmask;

--- a/lib/webrtcstreamer.js
+++ b/lib/webrtcstreamer.js
@@ -226,7 +226,7 @@ export default class WebRtcStreamer {
     // Mouse button state
     let buttonMask = 0;
 
-    this.keyboard = new Keyboard(document);
+    this.keyboard = new Keyboard({ target: document });
     this.keyboard.onkeyevent = (keysym, code, down) => {
       this.onKeyboardEvent({
         down,
@@ -234,7 +234,7 @@ export default class WebRtcStreamer {
       });
     };
 
-    this.mouse = new Mouse(elem);
+    this.mouse = new Mouse({ target: elem});
     this.mouse.onmousebutton = (x, y, down, bmask) => {
       if (down) {
         buttonMask |= bmask;

--- a/lib/webrtcstreamer.js
+++ b/lib/webrtcstreamer.js
@@ -227,7 +227,7 @@ export default class WebRtcStreamer {
     let buttonMask = 0;
 
     this.keyboard = new Keyboard({ target: document });
-    this.keyboard.onkeyevent = (keysym, code, down) => {
+    this.keyboard._onKeyEvent = (keysym, code, down) => {
       this.onKeyboardEvent({
         down,
         code: keysym
@@ -235,7 +235,7 @@ export default class WebRtcStreamer {
     };
 
     this.mouse = new Mouse({ target: elem});
-    this.mouse.onmousebutton = (x, y, down, bmask) => {
+    this.mouse._onMouseButton = this.mouse._onMouseMove = (x, y, down, bmask) => {
       if (down) {
         buttonMask |= bmask;
       } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rainforestqa/webrtc-client",
-  "version": "0.0.9",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1867,7 +1867,7 @@
     },
     "chalk": {
       "version": "1.1.3",
-      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "requires": {
         "ansi-styles": "^2.2.1",
@@ -6699,8 +6699,8 @@
       "dev": true
     },
     "noVNC": {
-      "version": "git+ssh://git@github.com/rainforestapp/noVNC.git#7fab786d849b00bac48f2df4107b1ad6441d7bdd",
-      "from": "git+ssh://git@github.com/rainforestapp/noVNC.git#npm-package"
+      "version": "git+ssh://git@github.com/rainforestapp/noVNC.git#5dd5be17ac67c0aaff55c3f4e661cbba32a3e6ba",
+      "from": "git+ssh://git@github.com/rainforestapp/noVNC.git"
     },
     "node-dir": {
       "version": "0.1.8",
@@ -8986,7 +8986,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
         "ansi-regex": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rainforestqa/webrtc-client",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "",
   "main": "./dist/index.js",
   "scripts": {


### PR DESCRIPTION
we switched to using our own fork of noVNC mouse / keyboard capture modules in #11, but didn't update the calls to their constructors.

[upstream expects just the target dom elements](https://github.com/novnc/noVNC/blob/77e261dba3ac942577e4fe9617340a39df42b6d6/core/input/mouse.js#L16) while our fork [expects a configuration object](https://github.com/rainforestapp/noVNC/blob/5dd5be17ac67c0aaff55c3f4e661cbba32a3e6ba/core/input/devices.js#L288)